### PR TITLE
Removed `final` keywords to add more flexibility.

### DIFF
--- a/src/BundleWithPlugins.php
+++ b/src/BundleWithPlugins.php
@@ -22,7 +22,7 @@ abstract class BundleWithPlugins extends Bundle
 
     abstract protected function getAlias();
 
-    final public function __construct(array $plugins = array())
+    public function __construct(array $plugins = array())
     {
         foreach ($this->alwaysRegisteredPlugins() as $plugin) {
             $this->registerPlugin($plugin);
@@ -36,7 +36,7 @@ abstract class BundleWithPlugins extends Bundle
     /**
      * @inheritdoc
      */
-    final public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container)
     {
         foreach ($this->registeredPlugins as $plugin) {
             $plugin->build($container);
@@ -46,7 +46,7 @@ abstract class BundleWithPlugins extends Bundle
     /**
      * @inheritdoc
      */
-    final public function boot()
+    public function boot()
     {
         foreach ($this->registeredPlugins as $plugin) {
             $plugin->boot($this->container);
@@ -66,7 +66,7 @@ abstract class BundleWithPlugins extends Bundle
     /**
      * @inheritdoc
      */
-    final public function getContainerExtension()
+    public function getContainerExtension()
     {
         return new ExtensionWithPlugins($this->getAlias(), $this->registeredPlugins);
     }

--- a/src/ConfigurationWithPlugins.php
+++ b/src/ConfigurationWithPlugins.php
@@ -2,10 +2,11 @@
 
 namespace Matthias\BundlePlugins;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-final class ConfigurationWithPlugins implements ConfigurationInterface
+class ConfigurationWithPlugins implements ConfigurationInterface
 {
     /**
      * @var string
@@ -35,11 +36,19 @@ final class ConfigurationWithPlugins implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root($this->rootNodeName);
 
+        $this->addPluginsConfig($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $rootNode
+     */
+    protected function addPluginsConfig(ArrayNodeDefinition $rootNode)
+    {
         foreach ($this->registeredPlugins as $plugin) {
             $pluginNode = $rootNode->children()->arrayNode($plugin->name());
             $plugin->addConfiguration($pluginNode);
         }
-
-        return $treeBuilder;
     }
 }

--- a/src/ExtensionWithPlugins.php
+++ b/src/ExtensionWithPlugins.php
@@ -5,7 +5,7 @@ namespace Matthias\BundlePlugins;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-final class ExtensionWithPlugins extends Extension
+class ExtensionWithPlugins extends Extension
 {
     /**
      * @var string
@@ -36,9 +36,7 @@ final class ExtensionWithPlugins extends Extension
 
         $processedConfiguration = $this->processConfiguration($configuration, $config);
 
-        foreach ($this->registeredPlugins as $plugin) {
-            $this->loadPlugin($container, $plugin, $processedConfiguration);
-        }
+        $this->loadPlugins($container, $processedConfiguration);
     }
 
     /**
@@ -55,6 +53,17 @@ final class ExtensionWithPlugins extends Extension
     public function getAlias()
     {
         return $this->alias;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param $processedConfiguration
+     */
+    protected function loadPlugins(ContainerBuilder $container, $processedConfiguration)
+    {
+        foreach ($this->registeredPlugins as $plugin) {
+            $this->loadPlugin($container, $plugin, $processedConfiguration);
+        }
     }
 
     /**


### PR DESCRIPTION
`ExtensionWithPlugins` and `ConfigurationWithPlugins` can now be extended when a bundle has specific/complex dependencies and behavior. In that regard, I also changed some `private` properties to `protected` so that sub-classes can access them.
In the same context, I added shorthands methods to load plugins (`ExtensionWithPlugins`) and add plugin config (`ConfigurationWithPlugins`).

Fixes #4
