### PR TITLE
Feature/prepend configs

### DIFF
--- a/src/BundlePlugin.php
+++ b/src/BundlePlugin.php
@@ -55,4 +55,13 @@ interface BundlePlugin
      * @return void
      */
     public function boot(ContainerInterface $container);
+
+    /**
+     * When the container is generated for the first time, this method is called
+     * to give an opportunity to prepend configuration for this or other bundles
+     *
+     * @param ContainerInterface $container
+     * @return void
+     */
+    public function prepend(ContainerBuilder $container);
 }

--- a/src/ExtensionWithPlugins.php
+++ b/src/ExtensionWithPlugins.php
@@ -3,9 +3,10 @@
 namespace Matthias\BundlePlugins;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-final class ExtensionWithPlugins extends Extension
+final class ExtensionWithPlugins extends Extension implements PrependExtensionInterface
 {
     /**
      * @var string
@@ -85,5 +86,17 @@ final class ExtensionWithPlugins extends Extension
         }
 
         return $processedConfiguration[$plugin->name()];
+    }
+
+    /**
+     * Allow an extension to prepend the extension configurations.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        foreach ($this->registeredPlugins as $plugin) {
+            $plugin->prepend($container);
+        }
     }
 }

--- a/src/SimpleBundlePlugin.php
+++ b/src/SimpleBundlePlugin.php
@@ -37,4 +37,13 @@ abstract class SimpleBundlePlugin implements BundlePlugin
     public function boot(ContainerInterface $container)
     {
     }
+
+    /**
+     * Override this method if your plugin needs to prepend configuration
+     *
+     * @inheritdoc
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+    }
 }

--- a/test/BarPlugin.php
+++ b/test/BarPlugin.php
@@ -40,4 +40,8 @@ class BarPlugin implements BundlePlugin
     {
         $container->get('bar.boot')->call();
     }
+
+    public function prepend(ContainerBuilder $container)
+    {
+    }
 }

--- a/test/CorePlugin.php
+++ b/test/CorePlugin.php
@@ -42,4 +42,8 @@ class CorePlugin implements BundlePlugin
     {
         $container->get('core.boot')->call();
     }
+
+    public function prepend(ContainerBuilder $container)
+    {
+    }
 }

--- a/test/FooPlugin.php
+++ b/test/FooPlugin.php
@@ -40,4 +40,8 @@ class FooPlugin implements BundlePlugin
     {
         $container->get('foo.boot')->call();
     }
+
+    public function prepend(ContainerBuilder $container)
+    {
+    }
 }


### PR DESCRIPTION
Added prepend methods to BundlePlugin interface and ExtensionWithPlugins (having this class implement PrependExtensionInterface), so plugins have an opportunity to prepend configuration (method is called in container compilation time)

Use case:
- A bundle SBPBundle that use another third party bundle, with a default configuration.
- The SBPBundle it's used in many apps, that should repeat that third party bundle configuration.
- Set default third party bundle configuration in prepend method in a CorePlugin, so no need to repeat that default configuration in every app that use SBPBundle 
