### PR TITLE
Fix travis build with php 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
   include:
     - php: 5.3
       env: SYMFONY_VERSION=2.3.*
+      dist: precise
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 7.0


### PR DESCRIPTION
Fixed the travis configuration. For now php 5.3 is not supported on Trusty image and dist should be changed. Without this change all builds will fail. Doc: https://docs.travis-ci.com/user/reference/trusty/#PHP-images

And what about php 7.1 and symfony 3.3? Is it necessary to add it?